### PR TITLE
Fix error when this npm module user installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf lib",
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "postpublish": "npm run clean",
-    "install": "cd test && npm install",
+    "setup": "npm install && cd test && npm install",
     "test": "cd test && npm run test",
     "version": "npm publish && git add -A",
     "postversion": "git push"


### PR DESCRIPTION
An error occurs when installing validate-typescript.
This pull request is a fix that avoids the error.
```
username@PC:~/project$ npm install validate-typescript

> validate-typescript@4.0.0 install ~/project/node_modules/validate-typescript
> cd test && npm install

sh: 1: cd: can't cd to test
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! validate-typescript@4.0.0 install: `cd test && npm install`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the validate-typescript@4.0.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/2019-03-13T25_67_89_000Z-debug.log
```

This error is because I've run `npm install validate-typescript`, which chained calls to the downloaded validate-typescript package's install.
(And the downloaded validate-typescript package does not have a `test` directory)

Empty the validate-typescript install script to avoid errors.
And I created a setup script that does the same thing as the current install script does.
Please run `npm run setup` when developing validate-typescript.
This is equivalent to the current `npm install`.

The same process as the current install script is moved to the `setup` name.
It contains `npm install`, so it can do the same thing as the current install script.
When developing validate-typescript, `npm run setup` can do the same as` npm install`.


Thank you for the great product.
